### PR TITLE
Throw exception when Trello item are not found

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,8 @@
             <directory suffix=".php">./src/Client/</directory>
             <directory suffix=".php">./src/Manager/</directory>
             <directory suffix=".php">./src/Model/</directory>
+            <directory suffix=".php">./src/Helper/</directory>
+            <directory suffix=".php">./src/Exception/</directory>
             <file>./src/BurndownGenerator.php</file>
         </whitelist>
     </filter>

--- a/src/BurndownGenerator.php
+++ b/src/BurndownGenerator.php
@@ -5,6 +5,7 @@ namespace TrelloBurndown;
 use Trello\Model\Board;
 use Trello\Model\Cardlist;
 use TrelloBurndown\Client\TrelloClient;
+use TrelloBurndown\Exception\TrelloItemNotFoundException;
 use TrelloBurndown\Manager\ActionManager;
 use TrelloBurndown\Manager\BoardManager;
 use TrelloBurndown\Manager\ListManager;
@@ -84,9 +85,10 @@ class BurndownGenerator
     public function addBoard(String $boardName)
     {
         $board = $this->boardManager->getBoard($boardName);
-        if ($board instanceof Board) {
-            $this->boards[] = $board;
+        if ($board ==  null || !$board instanceof Board) {
+            throw new TrelloItemNotFoundException('board', $boardName);
         }
+        $this->boards[] = $board;
     }
 
     /**
@@ -100,15 +102,24 @@ class BurndownGenerator
     {
         if ($boardName !== null) {
             $board = $this->boardManager->getBoard($boardName);
-            $list = $this->listManager->getListFromBoard($listName, $board);
-            if (!is_null($list) && $list instanceof Cardlist) {
-                $lists[] = $list;
+
+            if ($board ==  null || !$board instanceof Board) {
+                throw new TrelloItemNotFoundException('board', $boardName);
             }
+
+            $list = $this->listManager->getListFromBoard($listName, $board);
+
+            if ($list == null || !$list instanceof Cardlist) {
+                throw new TrelloItemNotFoundException('list', $listName);
+            }
+
+            $lists[] = $list;
         } else {
             $list = $this->listManager->getList($listName, $this->boards);
-            if (!is_null($list) && $list instanceof Cardlist) {
-                $lists[] = $list;
+            if ($list == null || !$list instanceof Cardlist) {
+                throw new TrelloItemNotFoundException('list', $listName);
             }
+            $lists[] = $list;
         }
     }
 

--- a/src/Exception/TrelloItemNotFoundException.php
+++ b/src/Exception/TrelloItemNotFoundException.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace TrelloBurndown\Exception;
+
+/**
+ * Class TrelloItemNotFoundException.
+ */
+class TrelloItemNotFoundException extends \Exception
+{
+    /**
+     * @var array
+     */
+    private static $itemTypes = [
+        'board',
+        'list',
+        'card',
+    ];
+
+    /**
+     * @var string
+     */
+    private $itemType;
+
+    /**
+     * @var string
+     */
+    private $itemName;
+
+    /**
+     * TrelloItemNotFoundException constructor.
+     *
+     * @param string          $itemType
+     * @param string          $itemName
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct(String $itemType, String $itemName, $code = 0, \Exception $previous = null)
+    {
+        $this->itemName = $itemName;
+        $this->itemType = $itemType;
+
+        try {
+            $message = self::getNotFoundMessage($itemType, $itemName);
+            parent::__construct($message, 404, $previous);
+        } catch (\Exception $e) {
+            parent::__construct($e->getMessage());
+        }
+    }
+
+    /**
+     * @param $itemType
+     * @param $itemName
+     *
+     * @return string
+     *
+     * @throws \Exception
+     */
+    private static function getNotFoundMessage($itemType, $itemName)
+    {
+        if (in_array($itemType, self::$itemTypes)) {
+            return 'The trello '.$itemType.' named '.$itemName.' could not be found.';
+        }
+
+        throw new \Exception('The declare Trello item type does not match any known type.');
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemName()
+    {
+        return $this->itemName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getItemType()
+    {
+        return $this->itemType;
+    }
+}

--- a/src/Manager/BoardManager.php
+++ b/src/Manager/BoardManager.php
@@ -30,9 +30,7 @@ class BoardManager
      *
      * @param string $boardName
      *
-     * @return \Trello\Model\Board
-     *
-     * @throws \Exception
+     * @return \Trello\Model\Board|null
      */
     public function getBoard(String $boardName)
     {
@@ -45,7 +43,7 @@ class BoardManager
 
         $manager = new Manager($this->client);
         if (!isset($boardId)) {
-            throw new \Exception("Board $boardName not found");
+            return;
         }
 
         return $manager->getBoard($boardId);

--- a/src/Manager/StoryPointManager.php
+++ b/src/Manager/StoryPointManager.php
@@ -145,7 +145,7 @@ class StoryPointManager
      * @param array  $doneLists
      * @param Sprint $sprint
      *
-     * @return int
+     * @return double
      */
     public function getTotalSprintStoryPoints(array $todoLists, array $wipLists, array $doneLists, Sprint $sprint)
     {
@@ -168,12 +168,12 @@ class StoryPointManager
     }
 
     /**
-     * @param $totalOfSprint
+     * @param double $totalOfSprint
      * @param Sprint $sprint
      *
      * @return float
      */
-    public function getAverageStoryPointsPerDay($totalOfSprint, Sprint $sprint)
+    public function getAverageStoryPointsPerDay(float $totalOfSprint, Sprint $sprint)
     {
         return round(($totalOfSprint / $sprint->getTotalWorkDays()), 2);
     }

--- a/test/TrelloBurndown/Tests/Exception/TrelloItemNotFoundExceptionTest.php
+++ b/test/TrelloBurndown/Tests/Exception/TrelloItemNotFoundExceptionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TrelloBurndown\Tests\Exception;
+
+
+use TrelloBurndown\Exception\TrelloItemNotFoundException;
+
+class TrelloItemNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testBoardException()
+    {
+        $notFoundException = new TrelloItemNotFoundException('board', 'test');
+
+        $this->assertEquals('test', $notFoundException->getItemName());
+        $this->assertEquals('board', $notFoundException->getItemType());
+        $this->assertEquals(1, preg_match('/board/', $notFoundException->getMessage()));
+        $this->assertEquals(1, preg_match('/test/', $notFoundException->getMessage()));
+    }
+
+    public function testCardException()
+    {
+        $notFoundException = new TrelloItemNotFoundException('card', 'test');
+
+        $this->assertEquals('test', $notFoundException->getItemName());
+        $this->assertEquals('card', $notFoundException->getItemType());
+        $this->assertEquals(1, preg_match('/card/', $notFoundException->getMessage()));
+        $this->assertEquals(1, preg_match('/test/', $notFoundException->getMessage()));
+    }
+
+    public function testListException()
+    {
+        $notFoundException = new TrelloItemNotFoundException('list', 'test');
+
+        $this->assertEquals('test', $notFoundException->getItemName());
+        $this->assertEquals('list', $notFoundException->getItemType());
+        $this->assertEquals(1, preg_match('/list/', $notFoundException->getMessage()));
+        $this->assertEquals(1, preg_match('/test/', $notFoundException->getMessage()));
+    }
+
+    public function testExceptionItemNotExist()
+    {
+        $notFoundException = new TrelloItemNotFoundException('test', 'test');
+
+        $this->assertEquals('test', $notFoundException->getItemName());
+        $this->assertEquals('test', $notFoundException->getItemType());
+        $this->assertEquals('The declare Trello item type does not match any known type.', $notFoundException->getMessage());
+
+    }
+}

--- a/test/TrelloBurndown/Tests/Generator/BurndownGeneratorTest.php
+++ b/test/TrelloBurndown/Tests/Generator/BurndownGeneratorTest.php
@@ -43,10 +43,9 @@ class BurndownGeneratorTest extends AbstractTestCase
     }
 
     /**
-     * Test exception when board cannot be find.
+     * Test exception when board cannot be found.
      *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Board test not found
+     * @expectedException TrelloBurndown\Exception\TrelloItemNotFoundException
      */
     public function testAddBoardWithWrongName()
     {
@@ -165,6 +164,38 @@ class BurndownGeneratorTest extends AbstractTestCase
 
         $this->assertInstanceOf(Cardlist::class, $burndownGenerator->getDoneLists()[1]);
         $this->assertCount(2, $burndownGenerator->getDoneLists());
+    }
+
+
+    /**
+     * Test Adding list when list is not found
+     *
+     * @expectedException TrelloBurndown\Exception\TrelloItemNotFoundException
+     * @expectedExceptionMessageRegExp /abc/
+     * * @expectedExceptionMessageRegExp /list/
+     */
+    public function testAddListWithWrongName()
+    {
+        $burndownGenerator = new BurndownGenerator($this->getTrelloClientMock());
+        $bordName = $this->getBoardsData()[0]['name'];
+        $listName = 'abc';
+        $burndownGenerator->addBoard($bordName);
+        $burndownGenerator->addWipList($listName);
+    }
+
+    /**
+     * Test Adding list when board is not found
+     *
+     * @expectedException TrelloBurndown\Exception\TrelloItemNotFoundException
+     * @expectedExceptionMessageRegExp /test/
+     * * @expectedExceptionMessageRegExp /board/
+     */
+    public function testAddListWithWrongBoardName()
+    {
+        $burndownGenerator = new BurndownGenerator($this->getTrelloClientMock());
+        $bordName = 'test';
+        $listName = 'abc';
+        $burndownGenerator->addWipList($listName, $bordName);
     }
 
     /**

--- a/test/TrelloBurndown/Tests/Manager/BoardManagerTest.php
+++ b/test/TrelloBurndown/Tests/Manager/BoardManagerTest.php
@@ -37,14 +37,11 @@ class BoardManagerTest extends AbstractTestCase
 
     /**
      * Test exception when board cannot be find.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Board test 3 not found
      */
     public function testGetBoardWithWrongName()
     {
         $trelloClient = $this->getTrelloClientMock();
         $boardManager = new BoardManager($trelloClient);
-        $boardManager->getBoard('test 3');
+        $this->assertNull($boardManager->getBoard('test 3'));
     }
 }


### PR DESCRIPTION
Trello item could be boards, lists, or cards.

The goal is to be able to catch exception when an item is not found and then, for example, set up a flash bag.
